### PR TITLE
Add comments system using GitHub Discussions via giscus

### DIFF
--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -1,3 +1,7 @@
+---
+disable_comments: true
+---
+
 # About me
 
 More coming soon!

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+---
+disable_comments: true
+---
+
 # Welcome to telescope.pics
 
 Welcome to telescope.pics!  The purpose of this website is to share the results of my lifelong interest in astrophotography! I've been interested in astronomy since my teen years, and spent decades juggling an engineering career with skywatching. In 1996, when Comet Hyakatuki splashed across the sky, I turned my SLR camera upward and never looked back! Transitioning out of film in the early 2000's, I continued over the years to try to improve my ability to photograph celestial events.
@@ -15,5 +19,3 @@ I wish to acknowledge my spouse Linda, my brother William, and my son Stephen fo
 
 Brian M. Kent, Ph.D.
 Dayton, Ohio USA
-
-# Coming Soon: Ability to leave comments and ask questions.

--- a/overrides/partials/comments.html
+++ b/overrides/partials/comments.html
@@ -1,0 +1,58 @@
+{% if not page.meta.disable_comments %}
+  <h2 id="__comments">{{ lang.t("meta.comments") }}</h2>
+  <!-- Insert generated snippet here -->
+
+  <script>
+      var script = document.createElement("script");
+      script.setAttribute("src", "https://" + "giscus.app" + "/client.js");
+      script.setAttribute("data-repo", "KentAstro/telescope.pics");
+      script.setAttribute("data-repo-id", "R_kgDOLC07Ag");
+      script.setAttribute("data-category", "Announcements");
+      script.setAttribute("data-category-id", "DIC_kwDOLC07As4Cc-EV");
+      script.setAttribute("data-mapping", "pathname");
+      script.setAttribute("data-strict", "0");
+      script.setAttribute("data-reactions-enabled", "1");
+      script.setAttribute("data-emit-metadata", "0");
+      script.setAttribute("data-theme", "dark_dimmed");
+      script.setAttribute("data-lang", "en");
+      script.setAttribute("crossorigin", "anonymous");
+      script.setAttribute("async", true);
+      document.currentScript.insertAdjacentElement("afterend", script);
+  </script>
+
+  <!-- Synchronize Giscus theme with palette -->
+  <script>
+    var giscus = document.querySelector("script[src*=giscus]")
+
+    // Set palette on initial load
+    var palette = __md_get("__palette")
+    if (palette && typeof palette.color === "object") {
+      var theme = palette.color.scheme === "slate"
+        ? "transparent_dark"
+        : "light"
+
+      // Instruct Giscus to set theme
+      giscus.setAttribute("data-theme", theme)
+    }
+
+    // Register event handlers after documented loaded
+    document.addEventListener("DOMContentLoaded", function() {
+      var ref = document.querySelector("[data-md-component=palette]")
+      ref.addEventListener("change", function() {
+        var palette = __md_get("__palette")
+        if (palette && typeof palette.color === "object") {
+          var theme = palette.color.scheme === "slate"
+            ? "transparent_dark"
+            : "light"
+
+          // Instruct Giscus to change theme
+          var frame = document.querySelector(".giscus-frame")
+          frame.contentWindow.postMessage(
+            { giscus: { setConfig: { theme } } },
+            "https://giscus.app"
+          )
+        }
+      })
+    })
+  </script>
+{% endif %}


### PR DESCRIPTION
Comments are enabled by default, and can be disabled by adding `disable_comments: true` to the front matter of a page:

```markdown
---
disable_comments: true
---

Page content [...]
```

This PR disables comments on the main home page and "About" page.

This largely uses the approach described in the documentation at https://squidfunk.github.io/mkdocs-material/setup/adding-a-comment-system/

However, as mkdocs-material's privacy plugin is not compatible with Giscus, this uses the alternative implementation approach described in mkdocs-material upstream PR 6502.